### PR TITLE
Fix incorrect site url in gatsby-config

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -7,7 +7,7 @@ require("dotenv").config({
 const config: GatsbyConfig = {
   siteMetadata: {
     title: `Architech Solutions`,
-    siteUrl: `https://www.yourdomain.tld`
+    siteUrl: `https://www.architech-solutions.com/`
   },
   // More easily incorporate content into your pages through automatic TypeScript type generation and better GraphQL IntelliSense.
   // If you use VSCode you can also use the GraphQL plugin


### PR DESCRIPTION
Update gatsby-config metadata to use correct siteURL: "https://www.architech-solutions.com/"