### PR TITLE
Github Actions: Pull Request Validation Gating and Production Deployment on Pull Request Merge

### DIFF
--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -17,4 +17,4 @@ jobs:
         with:
           access-token: ${{ secrets.REPO_ACCESS_TOKEN }}
           deploy-branch: deploy
-          skip-publish: true
+          skip-publish: false

--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  NPM_CONFIG_LEGACY_PEER_DEPS: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -1,0 +1,17 @@
+name: Production Deployment
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: enriikke/gatsby-gh-pages-action@v2.2.1
+        with:
+          access-token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          deploy-branch: deploy
+          skip-publish: true

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -1,0 +1,17 @@
+name: Pull Request Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: enriikke/gatsby-gh-pages-action@v2.2.1
+        with:
+          access-token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          deploy-branch: deploy
+          skip-publish: true

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  NPM_CONFIG_LEGACY_PEER_DEPS: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.architech-solutions.com

--- a/README.md
+++ b/README.md
@@ -63,14 +63,19 @@ Commands are run on "main" branch. Source files are on "main" branch. For deploy
 
     ```shell
     git add .
+    git commit -m <commit message>
     git push
     ```
 
-11. Once review is approved, code review can be merged into "main" branch.
+11. Once review is approved, code review can be merged into "main" branch. Remote branch is automatically deleted.
 
-12. Deploy changes to production site. This generates and commits static files to "deploy" branch.
+12. Deploy changes to production site. This is done automatically by github action when PR is merged in "main".
+    Emergency manual deployment can be done by doing the following on "main" after pulling latest changes into main:
 
     ```shell
+    git checkout main
+    git pull
+    npm run clean
     npm run deploy
     ```
 
@@ -79,6 +84,7 @@ Commands are run on "main" branch. Source files are on "main" branch. For deploy
     [Production Site](https://www.architech-solutions.com)
 
 ## 🥪 Stack
+- CI: [Github Action: Gatsby Publish](https://github.com/marketplace/actions/gatsby-publish)
 - Domain Registrar/DNS/Visit Metrics: [CloudFlare](https://www.cloudflare.com/)
 - Hosting: [GitHub Pages](https://pages.github.com/)
 - Frontend Meta Framework (SSG): [Gatsby](https://www.gatsbyjs.com/)
@@ -89,3 +95,4 @@ Commands are run on "main" branch. Source files are on "main" branch. For deploy
 - UI Components: [Aceternity](https://ui.aceternity.com/components)
 - Photo Assets: [Unplash](https://unsplash.com/)
 - Email Submission [Web3 Forms](https://web3forms.com/)
+- Form Validation [Formik](https://formik.org/docs)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "gatsby"
   ],
   "scripts": {
-    "deploy": "rd /s /q .\\node_modules\\.cache\\gh-pages>nul 2>&1|echo.>nul && gatsby build && gh-pages -d public -b deploy",
+    "deploy": "rd /s /q .\\node_modules\\.cache\\gh-pages>nul 2>&1|echo.>nul && gatsby clean && gatsby build && gh-pages -d public -b deploy",
     "develop": "gatsby develop",
     "start": "gatsby develop",
     "build": "gatsby build",


### PR DESCRIPTION
Leveraged this GitHub action helper for publishing Gatsby site to GitHub pages and created personal access token for use by GitHub action.
- https://github.com/marketplace/actions/gatsby-publish
- https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens

1. Generated new access token with repo permissions: https://github.com/settings/tokens
2. Registered token with repo GitHub actions: https://github.com/byue/byue.github.io/settings/secrets/actions

Notes:
- Publish for Production deployment is initially set to false for testing purposes.
- CNAME file is duplicated to root since static/CNAME is needed for manual deployment script but Github action uses CNAME at project root.

![image](https://github.com/user-attachments/assets/ffa3d267-570b-4d68-a166-74b6cca412f7)

![image](https://github.com/user-attachments/assets/12006741-d908-4eda-8abd-0dc032ac20d8)

